### PR TITLE
fix(security): pass middleware requests through auth proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       retries: 5
     security_opt:
       - no-new-privileges:true
+    networks:
+      - default
+      - middleware
+      - db
 
   db:
     image: ghcr.io/baosystems/postgis:13-3.4
@@ -35,6 +39,8 @@ services:
       retries: 5
     security_opt:
       - no-new-privileges:true
+    networks:
+      - db
 
   gateway:
     image: nginx
@@ -57,6 +63,8 @@ services:
       interval: 5s
       timeout: 1s
       retries: 5
+    networks:
+      - civil-registry
 
   identity-provider:
     image: "quay.io/keycloak/keycloak:25.0.6"
@@ -83,6 +91,8 @@ services:
     command: [ "start-dev", "--import-realm" ]
     security_opt:
       - no-new-privileges:true
+    networks:
+      - auth
 
   auth-proxy:
     image: "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
@@ -94,6 +104,9 @@ services:
         condition: service_healthy
     security_opt:
       - no-new-privileges:true
+    networks:
+      - auth
+      - civil-registry
 
   oauth-route-middleware:
     build: ./oauth-route-middleware
@@ -105,6 +118,9 @@ services:
       - no-new-privileges:true
     volumes:
       - ./config/oauth-route-middleware/dhis2Person.ds:/dhis2Person.ds:ro
+    networks:
+      - middleware
+      - auth
 
   seed:
     image: busybox
@@ -129,6 +145,9 @@ services:
         condition: service_healthy
       dhis2:
         condition: service_healthy
+    networks:
+      - default
+      - civil-registry
 
 volumes:
   db-dump: { }
@@ -136,3 +155,13 @@ volumes:
     driver: local
   postgresql:
     driver: local
+
+networks:
+  civil-registry:
+    internal: true
+  auth:
+    internal: true
+  middleware:
+    internal: true
+  db:
+    internal: true

--- a/oauth-route-middleware/src/main/resources/application.yaml
+++ b/oauth-route-middleware/src/main/resources/application.yaml
@@ -46,9 +46,8 @@ camel:
   servlet:
     mapping:
       context-path: "/api/*"
-  component:
-    fhir:
-      server-url: http://civil-registry:8080/fhir
+
+civil-registry-url: http://auth-proxy:4180/fhir
 
 management:
   endpoints:

--- a/oauth-route-middleware/src/main/resources/camel/find-route.camel.yaml
+++ b/oauth-route-middleware/src/main/resources/camel/find-route.camel.yaml
@@ -40,7 +40,7 @@
         - toD:
             # `fhir:search/searchByUrl` from the FHIR component permits only GET operations so this route relies on the HTTP component
             # to POST the search query in order to reduce the risk of the national ID leaking into the server access logs
-            uri: "{{camel.component.fhir.server-url}}/Person/_search"
+            uri: "{{civil-registry-url}}/Person/_search"
             parameters:
               httpMethod: POST
               oauth2ClientId: "{{oauth2.clientId}}"

--- a/oauth-route-middleware/src/test/java/org/hisp/dhis/integration/camel/route/AbstractRouteFunctionalTestCase.java
+++ b/oauth-route-middleware/src/test/java/org/hisp/dhis/integration/camel/route/AbstractRouteFunctionalTestCase.java
@@ -83,7 +83,7 @@ public class AbstractRouteFunctionalTestCase {
               "http://localhost:%s/realms/civil-registry/protocol/openid-connect/token",
               TestSocketUtils.findAvailableTcpPort());
       System.setProperty("oauth2.tokenEndpoint", identityProviderUrl);
-      System.setProperty("camel.component.fhir.server-url", fhirServerUrl);
+      System.setProperty("civil-registry-url", fhirServerUrl);
     }
   }
 }


### PR DESCRIPTION
isolate civil registry container network and other networks

rename component.fhir.server-url to civil-registry-url