### PR TITLE
feat: validate input and fhir response

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ The `Test` button in Route Manager permits you to try out the route once it is s
 
 * Sensitive data, like the national ID, should always be carried in the body of HTTP POST requests. Transmitting sensitive data in the body of POST requests, as opposed to including it in the URL query params, reduces the risk of personal identifiable information leaking into the server access logs.
 
+* The reference implementation does a basic and generic validation of the patient ID used [here](./civil-registry-plugin/src/LookupField/LookupField.tsx), i.e. it ensures it is not empty. This allows various formats of the ID that may be implemented across different use cases. Hence, it is advisable to validate the structure of the ID before passing it to the civil registry.
+
 * The reference implementation, by its nature, facilitates the searching and transferring of data which most likely contains personal identifying information. For this reason, a Privacy Impact Assessment (PIA) ought to be carried out before granting civil registry lookup access to DHIS2. In some jurisdictions (e.g., European Union), a PIA is required in order to comply with national regulations.
 
 # Support

--- a/civil-registry-plugin/i18n/en.pot
+++ b/civil-registry-plugin/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-07-30T14:16:56.281Z\n"
-"PO-Revision-Date: 2025-07-30T14:16:56.281Z\n"
+"POT-Creation-Date: 2025-11-27T08:26:56.766Z\n"
+"PO-Revision-Date: 2025-11-27T08:26:56.773Z\n"
 
 msgid ""
 "Civil registry mapping has not been set up; contact a system administrator. "
@@ -38,6 +38,9 @@ msgstr ""
 
 msgid "Failed to query civil registry. Please enter the person's details manually."
 msgstr "Failed to query civil registry. Please enter the person's details manually."
+
+msgid "Invalid Patient ID. The ID should only contain letters or numbers."
+msgstr "Invalid Patient ID. The ID should only contain letters or numbers."
 
 msgid "Search"
 msgstr "Search"

--- a/civil-registry-plugin/package.json
+++ b/civil-registry-plugin/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@dhis2/app-runtime": "^3.14.5",
     "@dhis2/ui": "^10.7.8",
+    "dompurify": "^3.3.0",
     "jsonata": "^2.0.6",
     "lodash": "^4.17.21",
     "typescript": "^5.4.5"

--- a/civil-registry-plugin/src/LookupField/LookupField.tsx
+++ b/civil-registry-plugin/src/LookupField/LookupField.tsx
@@ -124,7 +124,6 @@ export const LookupField = ({
             return
         }
 
-        console.error("FHIR person data:", fhirPerson)
         try {
             const lookupPerson = await jsonataExpression.evaluate(fhirPerson)
 

--- a/civil-registry-plugin/src/LookupField/LookupField.tsx
+++ b/civil-registry-plugin/src/LookupField/LookupField.tsx
@@ -40,7 +40,7 @@ const sanitizeString = (value: string): string => {
 
 const isValidValue = (value: string) => {
     // Generic validation: only ensure value exists
-    if (value === null || value === '' || value.length === 0) {
+    if (value === null || value === '') {
         console.error('Value is null or empty')
         return false
     }
@@ -125,6 +125,11 @@ export const LookupField = ({
 
         try {
             const lookupPerson = await jsonataExpression.evaluate(fhirPerson)
+
+            if (!lookupPerson || Object.keys(lookupPerson).length === 0) {
+                setMappingError(true)
+                return
+            }
 
             // Take data returned from Route and set enrollment field values.
             // Expects a flat object, and for keys and values to match the

--- a/civil-registry-plugin/src/LookupField/LookupField.tsx
+++ b/civil-registry-plugin/src/LookupField/LookupField.tsx
@@ -32,18 +32,21 @@ const registryErrMessage = i18n.t(
     "Failed to query civil registry. Please enter the person's details manually."
 )
 
-const IdErrorMessage = i18n.t(
-    "Invalid Patient ID. The ID should only contain letters or numbers."
-)
+const IdErrorMessage = i18n.t("Invalid Patient ID")
+
+const sanitizeString = (value: string): string => {
+    return DOMPurify.sanitize(value, { ALLOWED_TAGS: [] })
+}
 
 const isValidValue = (value: string) => {
     if (value === null || value === '') {
-        console.error("Value is null or empty")
+        console.error('Value is null or empty')
         return false
     }
 
-    const alphanumericPattern = /^[a-zA-Z0-9]+$/i
-    return alphanumericPattern.test(value)
+    // ID: alphanumeric, hyphens, dots, slashes, @
+    const idPattern = /^[a-zA-Z0-9\-_.@/]+$/
+    return idPattern.test(value)
 }
 
 type Props = {
@@ -113,20 +116,14 @@ export const LookupField = ({
     }, [personMapData])
 
     const handleSearch = useCallback(async () => {
-        if (!isValidValue(patientId)) {
-            console.error("Invalid Patient ID value")
+        const sanitizedId = sanitizeString(patientId).trim()
+
+        if (!isValidValue(sanitizedId)) {
+            console.error('Invalid Patient ID value')
             setIdError(true)
             return
         }
-        const fhirPerson = await query({ id: patientId })
-
-        // validation check
-        // Todo: validate actual fhir resource structure
-        if (fhirPerson == null || typeof fhirPerson !== 'object') {
-            console.error("Invalid data returned from registry lookup")
-            setMappingError(true)
-            return
-        }
+        const fhirPerson = await query({ id: sanitizedId })
 
         try {
             const lookupPerson = await jsonataExpression.evaluate(fhirPerson)
@@ -142,9 +139,7 @@ export const LookupField = ({
                     let sanitizedValue = value
 
                     if (typeof value === 'string') {
-                        sanitizedValue = DOMPurify.sanitize(value, {
-                            ALLOWED_TAGS: [],
-                        }).trim();
+                        sanitizedValue = sanitizeString(value).trim()
                     }
 
                     setFieldValue({ fieldId: key, value: sanitizedValue })

--- a/civil-registry-plugin/src/LookupField/LookupField.tsx
+++ b/civil-registry-plugin/src/LookupField/LookupField.tsx
@@ -39,14 +39,12 @@ const sanitizeString = (value: string): string => {
 }
 
 const isValidValue = (value: string) => {
-    if (value === null || value === '') {
+    // Generic validation: only ensure value exists
+    if (value === null || value === '' || value.length === 0) {
         console.error('Value is null or empty')
         return false
     }
-
-    // ID: alphanumeric, hyphens, dots, slashes, @
-    const idPattern = /^[a-zA-Z0-9\-_.@/]+$/
-    return idPattern.test(value)
+    return true
 }
 
 type Props = {

--- a/civil-registry-plugin/src/__tests__/integration.test.tsx
+++ b/civil-registry-plugin/src/__tests__/integration.test.tsx
@@ -183,6 +183,6 @@ test('failed query', async () => {
     // assert
     // should not try to set any fields, and log error
     expect(mockSetFieldValue).toHaveBeenCalledTimes(1)
-    expect(consoleErrorSpy).toHaveBeenCalledWith(expectedError)
+    expect(consoleErrorSpy).toHaveBeenCalledWith("Invalid Patient ID value")
     // todo: test alert?
 })

--- a/civil-registry-plugin/src/__tests__/integration.test.tsx
+++ b/civil-registry-plugin/src/__tests__/integration.test.tsx
@@ -175,23 +175,19 @@ test('failed query', async () => {
 
     // act
     const input = screen.getByLabelText('Patient ID')
-    await userEvent.type(input, 'not an id')
+
+    // test whitespace-only input
+    // triggers search, and validates to empty/invalid value
+    await userEvent.type(input, '   ')
 
     const searchButton = screen.getByText('Search')
     await userEvent.click(searchButton)
 
     // assert
-    // should not try to set any fields, and log error
+    // should not try to set any other fields, and log error
     expect(mockSetFieldValue).toHaveBeenCalledTimes(1)
     expect(consoleErrorSpy).toHaveBeenCalledWith("Invalid Patient ID value")
     // todo: test alert?
-
-    // test empty id
-    await userEvent.clear(input)
-    await userEvent.click(searchButton)
-
-    expect(mockSetFieldValue).toHaveBeenCalledTimes(1)
-    expect(consoleErrorSpy).toHaveBeenCalledWith("Invalid Patient ID value")
 })
 
 test('sanitization by removing HTML tags from string values', async () => {

--- a/civil-registry-plugin/src/__tests__/integration.test.tsx
+++ b/civil-registry-plugin/src/__tests__/integration.test.tsx
@@ -192,13 +192,6 @@ test('failed query', async () => {
 
     expect(mockSetFieldValue).toHaveBeenCalledTimes(1)
     expect(consoleErrorSpy).toHaveBeenCalledWith("Invalid Patient ID value")
-
-    // test ID with invalid characters: !, #
-    await userEvent.type(input, 'InvalidId!#')
-    await userEvent.click(searchButton)
-
-    expect(mockSetFieldValue).toHaveBeenCalledTimes(1)
-    expect(consoleErrorSpy).toHaveBeenCalledWith("Invalid Patient ID value")
 })
 
 test('sanitization by removing HTML tags from string values', async () => {

--- a/civil-registry-plugin/src/__tests__/integration.test.tsx
+++ b/civil-registry-plugin/src/__tests__/integration.test.tsx
@@ -193,8 +193,8 @@ test('failed query', async () => {
     expect(mockSetFieldValue).toHaveBeenCalledTimes(1)
     expect(consoleErrorSpy).toHaveBeenCalledWith("Invalid Patient ID value")
 
-    // test non-alphanumeric id
-    await userEvent.type(input, 'InvalidId!@#')
+    // test ID with invalid characters: !, #
+    await userEvent.type(input, 'InvalidId!#')
     await userEvent.click(searchButton)
 
     expect(mockSetFieldValue).toHaveBeenCalledTimes(1)

--- a/civil-registry-plugin/yarn.lock
+++ b/civil-registry-plugin/yarn.lock
@@ -3192,7 +3192,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
-"@types/trusted-types@^2.0.2":
+"@types/trusted-types@^2.0.2", "@types/trusted-types@^2.0.7":
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
@@ -5372,6 +5372,13 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
+
+dompurify@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.0.tgz#aaaadbb83d87e1c2fbb066452416359e5b62ec97"
+  integrity sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"


### PR DESCRIPTION
Implements [DEVREL-71](https://dhis2.atlassian.net/browse/DEVREL-71)

**Description**
This PR does a couple of things in terms of validation and sanitisation:
- It validates the structure of the  jsonata expression returned from evaluating the fhir response to ensure it is not empty before setting the other fields in the form. 
- It sanitises the values mapped into the jsonata expression. Done by trimming and removing html tags if any. This is a crucial step against all kinds of data that may be returned from the external server being queried. 
- It validates the ID value used to query the civil registry. Ensures it is non-empty at the very least.

**Tests**
- Added tests for invalid ID inputs that require validation, an invalid fhir response that is caught early on, and "unexpected" values with white spaces or html tags,  requiring sanitisation before being filled into the form. 

[DEVREL-71]: https://dhis2.atlassian.net/browse/DEVREL-71?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ